### PR TITLE
Slightly refactor `pkg/output`

### DIFF
--- a/cmd/kubeconform/main.go
+++ b/cmd/kubeconform/main.go
@@ -136,19 +136,6 @@ func (ap *arrayParam) Set(value string) error {
 	return nil
 }
 
-func getLogger(outputFormat string, printSummary, verbose bool) (output.Output, error) {
-	w := os.Stdout
-
-	switch {
-	case outputFormat == "text":
-		return output.Text(w, printSummary, verbose), nil
-	case outputFormat == "json":
-		return output.JSON(w, printSummary, verbose), nil
-	default:
-		return nil, fmt.Errorf("-output must be text or json")
-	}
-}
-
 func skipKindsMap(skipKindsCSV string) map[string]bool {
 	splitKinds := strings.Split(skipKindsCSV, ",")
 	skipKinds := map[string]bool{}
@@ -281,7 +268,7 @@ func realMain() int {
 	}()
 
 	var o output.Output
-	if o, err = getLogger(outputFormat, summary, verbose); err != nil {
+	if o, err = output.New(outputFormat, summary, verbose); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -44,24 +44,24 @@ func (o *jsono) Write(filename, kind, name, version string, err error, skipped b
 	s := status(kind, name, err, skipped)
 
 	switch s {
-	case VALID:
+	case statusValid:
 		st = "VALID"
 		o.nValid++
-	case INVALID:
+	case statusInvalid:
 		st = "INVALID"
 		msg = err.Error()
 		o.nInvalid++
-	case ERROR:
+	case statusError:
 		st = "ERROR"
 		msg = err.Error()
 		o.nErrors++
-	case SKIPPED:
+	case statusSkipped:
 		st = "SKIPPED"
 		o.nSkipped++
-	case EMPTY:
+	case statusEmpty:
 	}
 
-	if o.verbose || (s != VALID && s != SKIPPED && s != EMPTY) {
+	if o.verbose || (s != statusValid && s != statusSkipped && s != statusEmpty) {
 		o.results = append(o.results, result{Filename: filename, Kind: kind, Name: name, Version: version, Status: st, Msg: msg})
 	}
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -18,6 +18,19 @@ type Output interface {
 	Flush() error
 }
 
+func New(outputFormat string, printSummary, verbose bool) (Output, error) {
+	w := os.Stdout
+
+	switch {
+	case outputFormat == "text":
+		return Text(w, printSummary, verbose), nil
+	case outputFormat == "json":
+		return JSON(w, printSummary, verbose), nil
+	default:
+		return nil, fmt.Errorf("`outputFormat` must be 'text' or 'json'")
+	}
+}
+
 func status(kind, name string, err error, skipped bool) int {
 	if name == "" && kind == "" && err == nil && skipped == false {
 		return EMPTY

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,16 +1,19 @@
 package output
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/yannh/kubeconform/pkg/validator"
 )
 
 const (
 	_ = iota
-	VALID
-	INVALID
-	ERROR
-	SKIPPED
-	EMPTY
+	statusValid
+	statusInvalid
+	statusError
+	statusSkipped
+	statusEmpty
 )
 
 type Output interface {
@@ -33,19 +36,19 @@ func New(outputFormat string, printSummary, verbose bool) (Output, error) {
 
 func status(kind, name string, err error, skipped bool) int {
 	if name == "" && kind == "" && err == nil && skipped == false {
-		return EMPTY
+		return statusEmpty
 	}
 
 	if skipped {
-		return SKIPPED
+		return statusSkipped
 	}
 
 	if err != nil {
 		if _, ok := err.(validator.InvalidResourceError); ok {
-			return INVALID
+			return statusInvalid
 		}
-		return ERROR
+		return statusError
 	}
 
-	return VALID
+	return statusValid
 }

--- a/pkg/output/text.go
+++ b/pkg/output/text.go
@@ -37,27 +37,27 @@ func (o *text) Write(filename, kind, name, version string, reserr error, skipped
 
 	o.files[filename] = true
 	switch status(kind, name, reserr, skipped) {
-	case VALID:
+	case statusValid:
 		if o.verbose {
 			_, err = fmt.Fprintf(o.w, "%s - %s %s is valid\n", filename, kind, name)
 		}
 		o.nValid++
-	case INVALID:
+	case statusInvalid:
 		_, err = fmt.Fprintf(o.w, "%s - %s %s is invalid: %s\n", filename, kind, name, reserr)
 		o.nInvalid++
-	case ERROR:
+	case statusError:
 		if kind != "" && name != "" {
 			_, err = fmt.Fprintf(o.w, "%s - %s %s failed validation: %s\n", filename, kind, name, reserr)
 		} else {
 			_, err = fmt.Fprintf(o.w, "%s - failed validation: %s\n", filename, reserr)
 		}
 		o.nErrors++
-	case SKIPPED:
+	case statusSkipped:
 		if o.verbose {
 			_, err = fmt.Fprintf(o.w, "%s - %s %s skipped\n", filename, name, kind)
 		}
 		o.nSkipped++
-	case EMPTY: // sent to ensure we count the filename as parsed
+	case statusEmpty: // sent to ensure we count the filename as parsed
 	}
 
 	return err


### PR DESCRIPTION
This extracts `main.getLogger` to `output.New` and unexports the status constants from the `output` package.