### PR TITLE
scripts: Support for alternative filename format

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -179,6 +179,8 @@ $ ./scripts/openapi2jsonschema.py https://raw.githubusercontent.com/aws/amazon-s
 JSON schema written to trainingjob_v1.json
 ```
 
+The `FILENAME_FORMAT` environment variable can be used to change the output file name (Available variables: `kind`, `group`, `version`) (Default: `{kind}_{version}`).
+
 ### Speed comparison with Kubeval
 
 Running on a pretty large kubeconfigs setup, on a laptop with 4 cores:

--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -104,10 +104,15 @@ for crdFile in sys.argv[1:]:
             if y["kind"] != "CustomResourceDefinition":
                 continue
 
+            filename_format = os.getenv("FILENAME_FORMAT", "{kind}_{version}")
             filename = ""
             schemaJSON = ""
             if "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
-                filename = y["spec"]["names"]["kind"].lower()+"_"+y["spec"]["version"].lower()+".json"
+                filename = filename_format.format(
+                    kind=y["spec"]["names"]["kind"],
+                    group=y["spec"]["group"].split(".")[0],
+                    version=y["spec"]["version"],
+                ).lower() + ".json"
 
                 schema = y["spec"]["validation"]["openAPIV3Schema"]
                 schema = additional_properties(schema)
@@ -116,7 +121,11 @@ for crdFile in sys.argv[1:]:
             elif "spec" in y and "versions" in y["spec"]:
                 for version in y["spec"]["versions"]:
                     if "schema" in version and "openAPIV3Schema" in version["schema"]:
-                        filename = y["spec"]["names"]["kind"].lower()+"_"+version["name"].lower()+".json"
+                        filename = filename_format.format(
+                            kind=y["spec"]["names"]["kind"],
+                            group=y["spec"]["group"].split(".")[0],
+                            version=version["name"],
+                        ).lower() + ".json"
 
                         schema = version["schema"]["openAPIV3Schema"]
                         schema = additional_properties(schema)


### PR DESCRIPTION
This allows an alternative output file name format for the script, I wanted to use it with `kubeval` which is `{kind}-{group}-{version}`.

It may be the default for `kubeconform` as well (I haven't tested, but I have seen your issue to merge the 2 projects and I hope it will be considered seriously).

The `kindSuffix` part of the code I believe:

https://github.com/yannh/kubeconform/blob/9a56fc4176b6f917c6758b462b7b08a3dac3f518/pkg/registry/registry.go#L35-L41

https://github.com/instrumenta/kubeval/blob/529b532b1ea1ea002b1362640c0d52edcc02fc57/kubeval/kubeval.go#L75-L81

Thank you! ❤️