### PR TITLE
Add acceptance test that 404 errors from registry do not get cached

### DIFF
--- a/Dockerfile.bats
+++ b/Dockerfile.bats
@@ -1,5 +1,5 @@
 FROM bats/bats:v1.2.1
-RUN apk --no-cache add ca-certificates parallel
+RUN apk --no-cache add ca-certificates parallel python
 COPY bin/kubeconform /code/bin/
 COPY acceptance.bats /code/acceptance.bats
 COPY fixtures /code/fixtures

--- a/fixtures/registry/trainingjob-sagemaker-v1.json
+++ b/fixtures/registry/trainingjob-sagemaker-v1.json
@@ -10,7 +10,8 @@
       "type": "string"
     },
     "metadata": {
-      "type": "object"
+      "$ref": "https://kubernetesjsonschema.dev/v1.14.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+      "description": "Standard object metadata."
     },
     "spec": {
       "description": "TrainingJobSpec defines the desired state of TrainingJob",


### PR DESCRIPTION
The was no problem with caching 404 responses so I just added test to confirm that

---

I based my work on #26 because there was added utility function to start registry
Diff for review: https://github.com/Nitive/kubeconform/compare/cache-test...Nitive:do-not-cache-404-error-test