### PR TITLE
initial support for homebrew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,3 +29,12 @@ changelog:
   filters:
     exclude:
       - '^test:'
+brews:
+  -
+    tap:
+      owner: yannh
+      name: homebrew-yannh
+    homepage: "https://github.com/yannh/kubeconform"
+    description: "Kubeconform is a Kubernetes manifests validation tool"    
+    license: "Apache 2.0"
+    skip_upload: true


### PR DESCRIPTION
updates `.goreleaser.yml` file to include building the ruby file needed by homebrew (`dist/kubeconform.rb`).  This file is only generated when you do a `release` (ie not with a `build`).  This file needs to be checked in to the `yannh\homebrew-yannh` repo at the same time as each official release of `kubeconform`.  

It is possible to have `goreleaser` upload the file automatically but I don't know if you are cool with that as it needs a github token to do so.