### PR TITLE
Added ignore-stdin as a flag to work with CI.

### DIFF
--- a/cmd/kubeconform/main.go
+++ b/cmd/kubeconform/main.go
@@ -74,6 +74,10 @@ func realMain() int {
 	if len(cfg.Files) == 1 && cfg.Files[0] == "-" {
 		isStdin = true
 	}
+	// Ignore every data from stdin and check for files.
+	if cfg.IgnoreStdIn {
+		isStdin = false
+	}
 
 	var o output.Output
 	if o, err = output.New(cfg.OutputFormat, cfg.Summary, isStdin, cfg.Verbose); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Verbose                bool
 	IgnoreMissingSchemas   bool
 	IgnoreFilenamePatterns []string
+	IgnoreStdIn            bool
 	Help                   bool
 }
 
@@ -68,6 +69,7 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 	flags.StringVar(&skipKindsCSV, "skip", "", "comma-separated list of kinds to ignore")
 	flags.StringVar(&rejectKindsCSV, "reject", "", "comma-separated list of kinds to reject")
 	flags.BoolVar(&c.ExitOnError, "exit-on-error", false, "immediately stop execution when the first error is encountered")
+	flags.BoolVar(&c.IgnoreStdIn, "ignore-stdin", false, "ignores the stdin for the cli.")
 	flags.BoolVar(&c.IgnoreMissingSchemas, "ignore-missing-schemas", false, "skip files with missing schemas instead of failing")
 	flags.Var(&ignoreFilenamePatterns, "ignore-filename-pattern", "regular expression specifying paths to ignore (can be specified multiple times)")
 	flags.BoolVar(&c.Summary, "summary", false, "print a summary at the end")


### PR DESCRIPTION
Added a flag to ignore data from stdin.
It is very useful inside CI environment when you do not have a TTY.

```console
$ podman run --rm -i -v ./:/home/alarm/ archlinux:latest bash                                                                                                                          
cd /home/alarm
ls
app-namespaces.yaml
definitions
generate-app-namespaces
kubeconform
README.md
./kubeconform -skip Service,SealedSecret,Kustomization,HelmRepository,GitRepository,IPPool,HelmChart,HelmRelease,GlobalNetworkPolicy,ClusterIssuer,CustomResourceDefinition,Receiver,postgresql,RBACDefinition -summary -n 4 ./definitions
true
Summary: 0 resource found parsing stdin - Valid: 0, Invalid: 0, Errors: 0, Skipped: 0
```

```console
$ podman run --rm -i -v ./:/home/alarm/ archlinux:latest bash                                                                                                                       
cd /home/alarm
./kubeconform -ignore-stdin -skip Service,SealedSecret,Kustomization,HelmRepository,GitRepository,IPPool,HelmChart,HelmRelease,GlobalNetworkPolicy,ClusterIssuer,CustomResourceDefinition,Receiver,postgresql,RBACDefinition -summary -n 4 ./definitions
false
Summary: 150 resources found in 115 files - Valid: 79, Invalid: 0, Errors: 0, Skipped: 71
```