### PR TITLE
Skip empty yaml docs

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -114,6 +114,8 @@ for crdFile in sys.argv[1:]:
       f = open(crdFile)
     with f:
         for y in yaml.load_all(f, Loader=yaml.SafeLoader):
+            if y is None:
+                continue
             if "kind" not in y:
                 continue
             if y["kind"] != "CustomResourceDefinition":


### PR DESCRIPTION
for yaml files with a structure like

```yaml
# comment
---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
```

to avoid

```bash
Traceback (most recent call last):
  File "kubeconform/scripts/openapi2jsonschema.py", line 117, in <module>
    if "kind" not in y:
TypeError: argument of type 'NoneType' is not iterable
```