### PR TITLE
build: bump to use go1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as certs
+FROM alpine:3.14 as certs
 RUN apk add ca-certificates
 
 FROM scratch AS kubeconform

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ build-static:
 	CGO_ENABLED=0 GOFLAGS=-mod=vendor GOOS=linux GOARCH=amd64 GO111MODULE=on go build -trimpath -tags=netgo -ldflags "-extldflags=\"-static\""  -a -o bin/ ./...
 
 docker-test:
-	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.16 make test
+	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.17 make test
 
 docker-build-static:
-	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.16 make build-static
+	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.17 make build-static
 
 build-bats:
 	docker build -t bats -f Dockerfile.bats .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yannh/kubeconform
 
-go 1.16
+go 1.17
 
 require (
 	github.com/beevik/etree v1.1.0
@@ -9,3 +9,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.2.0
 )
+
+require github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ go 1.17
 require (
 	github.com/beevik/etree v1.1.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.2.0
 )
-
-require github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect


### PR DESCRIPTION
Update to the [latest go1.17](https://blog.golang.org/go1.17)