### PR TITLE
FIX: enable http_proxy environment variable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -231,6 +231,13 @@ bandwidth costs might be applicable. Since bandwidth from Github Packages within
 Github Container Registry to also be usable for free within Github Actions in the future. If that were not to be the
 case, I might publish the Docker image to a different platform.
 
+### Proxy support
+
+Kubeconform will respect the HTTPS_PROXY variable when downloading schema files.
+
+```
+$ HTTPS_PROXY=proxy.local bin/kubeconform fixtures/valid.yaml
+```
 ### Speed comparison with Kubeval
 
 Running on a pretty large kubeconfigs setup, on a laptop with 4 cores:

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -281,3 +281,10 @@ resetCacheFolder() {
   [ "$status" -eq 0 ]
   [ "$output" = 'Summary: 2 resources found in 1 file - Valid: 2, Invalid: 0, Errors: 0, Skipped: 0' ]
 }
+
+@test "Should support HTTPS_PROXY" {
+  # This only tests that the HTTPS_PROXY variable is picked up and that it tries to use it
+  run bash -c "HTTPS_PROXY=127.0.0.1:1234 bin/kubeconform fixtures/valid.yaml"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"proxyconnect tcp: dial tcp 127.0.0.1:1234: connect: connection refused"* ]]
+}

--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -28,7 +28,7 @@ func newHTTPRegistry(schemaPathTemplate string, cacheFolder string, strict bool,
 		MaxIdleConns:       100,
 		IdleConnTimeout:    3 * time.Second,
 		DisableCompression: true,
-		Proxy:		    http.ProxyFromEnvironment,
+		Proxy:              http.ProxyFromEnvironment,
 	}
 
 	if skipTLS {

--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -28,6 +28,7 @@ func newHTTPRegistry(schemaPathTemplate string, cacheFolder string, strict bool,
 		MaxIdleConns:       100,
 		IdleConnTimeout:    3 * time.Second,
 		DisableCompression: true,
+		Proxy:		    http.ProxyFromEnvironment,
 	}
 
 	if skipTLS {


### PR DESCRIPTION
This PR enables support for http_proxy environment variable as described in the function description https://pkg.go.dev/net/http#ProxyFromEnvironment

Test without proxy environment variable: 
` ./bin/kubeconform fixtures
fixtures/crd_schema.yaml - CustomResourceDefinition trainingjobs.sagemaker.aws.amazon.com failed validation: failed downloading schema at https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone/customresourcedefinition-apiextensions-v1beta1.json: Get "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone/customresourcedefinition-apiextensions-v1beta1.json": dial tcp 185.199.111.133:443: connect: connection refused`

Test with proxy environment set: 
`
https_proxy=proxy.local:8080 ./bin/kubeconform fixtures
fixtures/crd_schema.yaml - CustomResourceDefinition trainingjobs.sagemaker.aws.amazon.com failed validation: could not find schema for CustomResourceDefinition
fixtures/duplicates-skipped-kinds.yaml - SkipThisKind identical failed validation: could not find schema for SkipThisKind
fixtures/duplicates-skipped-kinds.yaml - SkipThisKind identical failed validation: could not find schema for SkipThisKind
`

