### PR TITLE
Also support items elements in yaml

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -113,14 +113,20 @@ for crdFile in sys.argv[1:]:
     else:
       f = open(crdFile)
     with f:
+        defs = []
         for y in yaml.load_all(f, Loader=yaml.SafeLoader):
             if y is None:
                 continue
+            if "items" in y:
+                defs.extend(y["items"])
             if "kind" not in y:
                 continue
             if y["kind"] != "CustomResourceDefinition":
                 continue
+            else:
+                defs.append(y)
 
+        for y in defs:
             filename_format = os.getenv("FILENAME_FORMAT", "{kind}_{version}")
             filename = ""
             if "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:


### PR DESCRIPTION
This makes it easy for generating specs out of all crds that are deployed to a cluster by simply running something like 

```
kubectl get crds -o yaml > crds.yaml
python3 openapi2jsonschema.py crds.yaml
```
