### PR TITLE
Add -v flag to output version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
       - -a
     ldflags:
       - -extldflags "-static"
-      - -X github.com/yannh/kubeconform/pkg/config.version={{.Tag}}
+      - -X main.version={{.Tag}}
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
       - -a
     ldflags:
       - -extldflags "-static"
+      - -X github.com/yannh/kubeconform/pkg/config.version={{.Tag}}
 
 archives:
   - format: tar.gz

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,7 @@ Usage: ./bin/kubeconform [OPTION]... [FILE OR FOLDER]...
         disallow additional properties not in schema
   -summary
         print a summary at the end (ignored for junit output)
+  -v	show version information
   -verbose
         print results for all resources (ignored for tap and junit output)
 ```

--- a/cmd/kubeconform/main.go
+++ b/cmd/kubeconform/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/yannh/kubeconform/pkg/validator"
 )
 
+var version = "development"
+
 func processResults(cancel context.CancelFunc, o output.Output, validationResults <-chan validator.Result, exitOnError bool) <-chan bool {
 	success := true
 	result := make(chan bool)
@@ -49,6 +51,7 @@ func realMain() int {
 	if cfg.Help {
 		return 0
 	} else if cfg.Version {
+		fmt.Println(version)
 		return 0
 	} else if out != "" {
 		fmt.Println(out)

--- a/cmd/kubeconform/main.go
+++ b/cmd/kubeconform/main.go
@@ -48,6 +48,8 @@ func realMain() int {
 	cfg, out, err := config.FromFlags(os.Args[0], os.Args[1:])
 	if cfg.Help {
 		return 0
+	} else if cfg.Version {
+		return 0
 	} else if out != "" {
 		fmt.Println(out)
 		return 1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 )
 
-var version = "development"
-
 type Config struct {
 	Cache                  string
 	CPUProfileFile         string
@@ -100,10 +98,6 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 
 	if c.Help {
 		flags.Usage()
-	}
-
-	if c.Version {
-		fmt.Println(version)
 	}
 
 	return c, buf.String(), err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+var version = "development"
+
 type Config struct {
 	Cache                  string
 	CPUProfileFile         string
@@ -26,6 +28,7 @@ type Config struct {
 	IgnoreMissingSchemas   bool
 	IgnoreFilenamePatterns []string
 	Help                   bool
+	Version                bool
 }
 
 type arrayParam []string
@@ -79,6 +82,7 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 	flags.StringVar(&c.Cache, "cache", "", "cache schemas downloaded via HTTP to this folder")
 	flags.StringVar(&c.CPUProfileFile, "cpu-prof", "", "debug - log CPU profiling to file")
 	flags.BoolVar(&c.Help, "h", false, "show help information")
+	flags.BoolVar(&c.Version, "v", false, "show version information")
 	flags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTION]... [FILE OR FOLDER]...\n", progName)
 
@@ -96,6 +100,10 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 
 	if c.Help {
 		flags.Usage()
+	}
+
+	if c.Version {
+		fmt.Println(version)
 	}
 
 	return c, buf.String(), err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,6 +71,19 @@ func TestFromFlags(t *testing.T) {
 			},
 		},
 		{
+			[]string{"-v"},
+			Config{
+				Files:             []string{},
+				Version:           true,
+				KubernetesVersion: "master",
+				NumberOfWorkers:   4,
+				OutputFormat:      "text",
+				SchemaLocations:   nil,
+				SkipKinds:         map[string]struct{}{},
+				RejectKinds:       map[string]struct{}{},
+			},
+		},
+		{
 			[]string{"-skip", "a,b,c"},
 			Config{
 				Files:             []string{},


### PR DESCRIPTION
This will output the version based off the git tag, e.g.:

```
» ./bin/kubeconform -v
development
```