### PR TITLE
feat(output/tap): Output qualified resource name

### DIFF
--- a/pkg/output/tap.go
+++ b/pkg/output/tap.go
@@ -40,11 +40,11 @@ func (o *tapo) Write(res validator.Result) error {
 	switch res.Status {
 	case validator.Valid:
 		sig, _ := res.Resource.Signature()
-		fmt.Fprintf(o.w, "ok %d - %s (%s)\n", o.index, res.Resource.Path, sig.Kind)
+		fmt.Fprintf(o.w, "ok %d - %s (%s)\n", o.index, res.Resource.Path, sig.QualifiedName())
 
 	case validator.Invalid:
 		sig, _ := res.Resource.Signature()
-		fmt.Fprintf(o.w, "not ok %d - %s (%s): %s\n", o.index, res.Resource.Path, sig.Kind, res.Err.Error())
+		fmt.Fprintf(o.w, "not ok %d - %s (%s): %s\n", o.index, res.Resource.Path, sig.QualifiedName(), res.Err.Error())
 
 	case validator.Empty:
 		fmt.Fprintf(o.w, "ok %d - %s (empty)\n", o.index, res.Resource.Path)
@@ -53,7 +53,8 @@ func (o *tapo) Write(res validator.Result) error {
 		fmt.Fprintf(o.w, "not ok %d - %s: %s\n", o.index, res.Resource.Path, res.Err.Error())
 
 	case validator.Skipped:
-		fmt.Fprintf(o.w, "ok %d #skip - %s\n", o.index, res.Resource.Path)
+		sig, _ := res.Resource.Signature()
+		fmt.Fprintf(o.w, "ok %d - %s (%s) # skip\n", o.index, res.Resource.Path, sig.QualifiedName())
 	}
 
 	return nil

--- a/pkg/output/tap_test.go
+++ b/pkg/output/tap_test.go
@@ -36,7 +36,7 @@ metadata:
 					Err:    nil,
 				},
 			},
-			"TAP version 13\nok 1 - deployment.yml (Deployment)\n1..1\n",
+			"TAP version 13\nok 1 - deployment.yml (apps/v1/Deployment//my-app)\n1..1\n",
 		},
 		{
 			"a single deployment, verbose, with summary",
@@ -57,7 +57,7 @@ metadata:
 					Err:    nil,
 				},
 			},
-			"TAP version 13\nok 1 - deployment.yml (Deployment)\n1..1\n",
+			"TAP version 13\nok 1 - deployment.yml (apps/v1/Deployment//my-app)\n1..1\n",
 		},
 	} {
 		w := new(bytes.Buffer)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -119,3 +119,8 @@ func (res *Resource) Resources() []Resource {
 
 	return []Resource{*res}
 }
+
+// QualifiedName returns a string for a signature in the format version/kind/namespace/name
+func (sig *Signature) QualifiedName() string {
+	return fmt.Sprintf("%s/%s/%s/%s", sig.Version, sig.Kind, sig.Namespace, sig.Name)
+}


### PR DESCRIPTION
This is an improvement suggestion for the TAP output. With only the resource kind in the output, it can be impossible to know which resource is being validated:

```
ok 48 - stdin (RoleBinding)
ok 49 - stdin (RoleBinding)
ok 50 - stdin (RoleBinding)
ok 51 - stdin (RoleBinding)
```

This PR replaces the resource `kind` by a "qualified" resource name formatted `version/kind/namespace/name`: 

```
ok 48 - stdin (rbac.authorization.k8s.io/v1/RoleBinding/ns1/admin)
ok 49 - stdin (rbac.authorization.k8s.io/v1/RoleBinding/ns2/admin)
ok 50 - stdin (rbac.authorization.k8s.io/v1/RoleBinding/ns3/admin)
ok 51 - stdin (rbac.authorization.k8s.io/v1/RoleBinding/ns4/admin)
```

It also adds the signature to skipped resources:

```
ok 25 #skip - stdin
```

```
ok 24 - stdin (bitnami.com/v1alpha1/SealedSecret/some-ns/a-secret) # skip
```