### PR TITLE
add constructor to handle equal sign (=)

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -72,7 +72,7 @@ def allow_null_optional_fields(data, parent=None, grand_parent=None, key=None):
             elif isinstance(v, str):
                 is_non_null_type = k == "type" and v != "null"
                 has_required_fields = grand_parent and "required" in grand_parent
-                if is_non_null_type and not has_required_field:
+                if is_non_null_type and not has_required_fields:
                     new_v = [v, "null"]
             new[k] = new_v
         return new
@@ -106,6 +106,16 @@ def write_schema_file(schema, filename):
     print("JSON schema written to {filename}".format(filename=filename))
 
 
+def construct_value(load, node):
+    # Handle nodes that start with '='
+    # See https://github.com/yaml/pyyaml/issues/89
+    if not isinstance(node, yaml.ScalarNode):
+        raise yaml.constructor.ConstructorError(
+            "while constructing a value",
+            node.start_mark,
+            "expected a scalar, but found %s" % node.id, node.start_mark
+        )
+    yield str(node.value)
 
 
 if __name__ == "__main__":
@@ -120,6 +130,7 @@ if __name__ == "__main__":
         f = open(crdFile)
       with f:
           defs = []
+          yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:value', construct_value)
           for y in yaml.load_all(f, Loader=yaml.SafeLoader):
               if y is None:
                   continue


### PR DESCRIPTION
Equal sign (=) was not parsed properly by pyyaml.
Added constructor to parse equal sign as string.
Related issue: https://github.com/yannh/kubeconform/issues/103