### PR TITLE
fix: change flag parse error handling to return errors instead of exiting

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -11,6 +11,12 @@ resetCacheFolder() {
   [ "${lines[0]}" == 'Usage: bin/kubeconform [OPTION]... [FILE OR FOLDER]...' ]
 }
 
+@test "Fail and display help when using an incorrect flag" {
+  run bin/kubeconform -xyz
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" == 'flag provided but not defined: -xyz' ]
+}
+
 @test "Pass when parsing a valid Kubernetes config YAML file" {
   run bin/kubeconform -summary fixtures/valid.yaml
   [ "$status" -eq 0 ]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ func splitCSV(csvStr string) map[string]struct{} {
 func FromFlags(progName string, args []string) (Config, string, error) {
 	var schemaLocationsParam, ignoreFilenamePatterns arrayParam
 	var skipKindsCSV, rejectKindsCSV string
-	flags := flag.NewFlagSet(progName, flag.ExitOnError)
+	flags := flag.NewFlagSet(progName, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 


### PR DESCRIPTION
Currently, if flag parsing fails, kubeconform exits with status 2 but no error message. This is because `ExitOnError` means `flags.Parse` actually calls `os.Exit` directly, rather than returning the error to the caller, which seems to have been what the rest of the program assumes. In combination with `flags.SetOutput`, the error message is written to a buffer which is never printed to the user.

This PR changes to `ContinueOnError`, which instead returns the error, leading to the buffer with the error message to be printed before exiting.

As a note, it also means the exit code will be 1 instead of 2 on flag parse errors, since that is what is currently done in `realMain` on errors from `config.FromFlags`. Not sure if this is something that would be considered a breaking change?