### PR TITLE
use max initial buffer for stream scanner

### DIFF
--- a/pkg/resource/stream.go
+++ b/pkg/resource/stream.go
@@ -47,12 +47,10 @@ func FromStream(ctx context.Context, path string, r io.Reader) (<-chan Resource,
 	errors := make(chan error)
 
 	go func() {
-		const initialBufSize = 4 * 1024 * 1024 // Start with 4MB
-		const maxBufSize = 256 * 1024 * 1024   // Start with 4MB
-
+		const maxBufSize = 256 * 1024 * 1024
 		scanner := bufio.NewScanner(r)
-		buf := make([]byte, initialBufSize)
-		scanner.Buffer(buf, maxBufSize) // Resize up to 256MB
+		buf := make([]byte, maxBufSize)
+		scanner.Buffer(buf, maxBufSize)
 		scanner.Split(SplitYAMLDocument)
 
 	SCAN:


### PR DESCRIPTION
There is a bug related to the buffer. I have a stream of docs around 8MB and two documents fail yaml parsing.
The yaml is incomplete and fails being parsed which let me to believe its related to the buffer.

If I increase the initial buffer it works perfectly fine.
If I decrease the initial buffer I get even more documents which fail.

For now this pr just sets the max buffer size as initial one which is allocated.
Not perfect but it works or at least raises the issue. 
