### PR TITLE
add {{ .Group }} variable to schema location options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -194,6 +194,7 @@ Here are the variables you can use in -schema-location:
  * *StrictSuffix* - "-strict" or "" depending on whether validation is running in strict mode or not
  * *ResourceKind* - Kind of the Kubernetes Resource
  * *ResourceAPIVersion* - Version of API used for the resource - "v1" in "apiVersion: monitoring.coreos.com/v1"
+ * *Group* - the group name as stated in this resource's definition - "monitoring.coreos.com" in "apiVersion: monitoring.coreos.com/v1"
  * *KindSuffix* - suffix computed from apiVersion - for compatibility with Kubeval schema registries
 
 ### Converting an OpenAPI file to a JSON Schema

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -61,12 +61,14 @@ func schemaPath(tpl, resourceKind, resourceAPIVersion, k8sVersion string, strict
 		StrictSuffix                string
 		ResourceKind                string
 		ResourceAPIVersion          string
+		Group                       string
 		KindSuffix                  string
 	}{
 		normalisedVersion,
 		strictSuffix,
 		strings.ToLower(resourceKind),
 		groupParts[len(groupParts)-1],
+		groupParts[0],
 		kindSuffix,
 	}
 


### PR DESCRIPTION
Hi!

I'd like to add support for schema-locations that contain multiple schemas divided by the name of the groups those schemas belong to. This can be very useful for testing CRDs.

What do you think?:)