### PR TITLE
127 time to testcases

### DIFF
--- a/pkg/output/junit.go
+++ b/pkg/output/junit.go
@@ -48,6 +48,7 @@ type TestSuite struct {
 type TestCase struct {
 	XMLName   xml.Name         `xml:"testcase"`
 	Name      string           `xml:"name,attr"`
+	Time      int     		   `xml:"time,attr"`
 	ClassName string           `xml:"classname,attr"`
 	Skipped   *TestCaseSkipped `xml:"skipped,omitempty"`
 	Error     *TestCaseError   `xml:"error,omitempty"`

--- a/pkg/output/junit.go
+++ b/pkg/output/junit.go
@@ -48,8 +48,8 @@ type TestSuite struct {
 type TestCase struct {
 	XMLName   xml.Name         `xml:"testcase"`
 	Name      string           `xml:"name,attr"`
-	Time      int              `xml:"time,attr"`
 	ClassName string           `xml:"classname,attr"`
+	Time      int              `xml:"time,attr"`
 	Skipped   *TestCaseSkipped `xml:"skipped,omitempty"`
 	Error     *TestCaseError   `xml:"error,omitempty"`
 	Failure   []TestCaseError  `xml:"failure,omitempty"`

--- a/pkg/output/junit.go
+++ b/pkg/output/junit.go
@@ -48,7 +48,7 @@ type TestSuite struct {
 type TestCase struct {
 	XMLName   xml.Name         `xml:"testcase"`
 	Name      string           `xml:"name,attr"`
-	Time      int     		   `xml:"time,attr"`
+	Time      int              `xml:"time,attr"`
 	ClassName string           `xml:"classname,attr"`
 	Skipped   *TestCaseSkipped `xml:"skipped,omitempty"`
 	Error     *TestCaseError   `xml:"error,omitempty"`


### PR DESCRIPTION
**Changes**
- Added `Time` to `testcase` struct

Didn't see much impact in terms of performance. I have included a small snippet of yaml for testing but have also tested this against our entire platform as well and haven't seen any much difference.

**Testing**
`example.yaml` for the pr (have tested these changes against our environment as well)
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: example
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: example
  namespace: example
---
# Source: upstream/charts/podinfo/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-podinfo
  labels:
    helm.sh/chart: podinfo-6.1.8
    app.kubernetes.io/name: release-name-podinfo
    app.kubernetes.io/version: "6.1.8"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 9898
      targetPort: http
      protocol: TCP
      name: http
    - port: 9999
      targetPort: grpc
      protocol: TCP
      name: grpc
  selector:
    app.kubernetes.io/name: release-name-podinfo
```

kubeconform command
```sh
time kubeconform --summary --strict --kubernetes-version 1.22.9 --output junit example.yaml
```

**Results**

Without `time` in `testcase`
<img width="856" alt="image" src="https://user-images.githubusercontent.com/102072201/194116217-ac40f00f-a93d-46a3-a2a3-0362cd1b91ca.png">

With `time` in `testcase`
<img width="847" alt="image" src="https://user-images.githubusercontent.com/102072201/194117135-53fe8a97-3fb8-4808-b62c-e3395b04f8fc.png">

**Why is this valueable?**
* Allows the ability to upload results to test aggregator's
  * In our particular usecase [buildkite test analytics](https://buildkite.com/docs/test-analytics)
  * because `time` is missing in `testcases` test analytics does not recognize the output as valid xml
* Allows us up to keep a living record of passing/failiing validations
* Allows us to see our environments become more stable as we update and add more custom schemas to validations


cc/ https://github.com/yannh/kubeconform/issues/127