### PR TITLE
Do not expose internal CPU profiling option as flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,8 +74,6 @@ $ ./bin/kubeconform -h
 Usage: ./bin/kubeconform [OPTION]... [FILE OR FOLDER]...
   -cache string
         cache schemas downloaded via HTTP to this folder
-  -cpu-prof string
-        debug - log CPU profiling to file
   -debug
         print debug information
   -exit-on-error
@@ -103,7 +101,7 @@ Usage: ./bin/kubeconform [OPTION]... [FILE OR FOLDER]...
         disallow additional properties not in schema or duplicated keys
   -summary
         print a summary at the end (ignored for junit output)
-  -v	show version information
+  -v    show version information
   -verbose
         print results for all resources (ignored for tap and junit output)
 ```

--- a/cmd/kubeconform/main.go
+++ b/cmd/kubeconform/main.go
@@ -69,8 +69,9 @@ func realMain() int {
 		return 1
 	}
 
-	if cfg.CPUProfileFile != "" {
-		f, err := os.Create(cfg.CPUProfileFile)
+	cpuProfileFile := os.Getenv("KUBECONFORM_CPUPROFILE_FILE")
+	if cpuProfileFile != "" {
+		f, err := os.Create(cpuProfileFile)
 		if err != nil {
 			log.Fatal("could not create CPU profile: ", err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 
 type Config struct {
 	Cache                  string
-	CPUProfileFile         string
 	Debug                  bool
 	ExitOnError            bool
 	Files                  []string
@@ -79,7 +78,6 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 	flags.BoolVar(&c.Verbose, "verbose", false, "print results for all resources (ignored for tap and junit output)")
 	flags.BoolVar(&c.SkipTLS, "insecure-skip-tls-verify", false, "disable verification of the server's SSL certificate. This will make your HTTPS connections insecure")
 	flags.StringVar(&c.Cache, "cache", "", "cache schemas downloaded via HTTP to this folder")
-	flags.StringVar(&c.CPUProfileFile, "cpu-prof", "", "debug - log CPU profiling to file")
 	flags.BoolVar(&c.Help, "h", false, "show help information")
 	flags.BoolVar(&c.Version, "v", false, "show version information")
 	flags.Usage = func() {


### PR DESCRIPTION
CPU Profiling is only used for development purposes, and should not be exposed directly to the user via a flag. It can not be enabled via Environment variable.