### PR TITLE
Copy kubeconform to /usr/bin/kubeconform

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -8,5 +8,5 @@ LABEL org.opencontainers.image.authors="yann@mandragor.org" \
       org.opencontainers.image.url="https://github.com/yannh/kubeconform/"
 MAINTAINER Yann HAMON <yann@mandragor.org>
 RUN apk add ca-certificates
-COPY kubeconform /
-ENTRYPOINT ["/kubeconform"]
+COPY kubeconform ./usr/bin/kubeconform
+ENTRYPOINT ["kubeconform"]


### PR DESCRIPTION
Copy kubeconform directory to a directory that's in your PATH to avoid "kubeconform command not found" errors, e.g. issue #144. The kubeconform command should work now and be consistent with the instructions, instead of needing /kubeconform. 