### PR TITLE
Replace {group} with the full group name.

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
                       if "schema" in version and "openAPIV3Schema" in version["schema"]:
                           filename = filename_format.format(
                               kind=y["spec"]["names"]["kind"],
-                              group=y["spec"]["group"].split(".")[0],
+                              group=y["spec"]["group"],
                               version=version["name"],
                           ).lower() + ".json"
 
@@ -160,7 +160,7 @@ if __name__ == "__main__":
                       elif "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
                           filename = filename_format.format(
                               kind=y["spec"]["names"]["kind"],
-                              group=y["spec"]["group"].split(".")[0],
+                              group=y["spec"]["group"],
                               version=version["name"],
                           ).lower() + ".json"
 
@@ -169,7 +169,7 @@ if __name__ == "__main__":
               elif "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
                   filename = filename_format.format(
                       kind=y["spec"]["names"]["kind"],
-                      group=y["spec"]["group"].split(".")[0],
+                      group=y["spec"]["group"],
                       version=y["spec"]["version"],
                   ).lower() + ".json"
 


### PR DESCRIPTION
Kubeconform expects `{{ .Group }}` to be the full group name, e.g. `cert-manager.io`. But openapi2jsonschema.py replaces `{group}` with the abbreviated group name, e.g. `cert-manager`. Since the only purpose of the script is to make schema files for consumption by kubeconform, it seems like the script should use the full group name.