### PR TITLE
feat: support passing mutiple files in a single flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -165,6 +165,11 @@ $ echo $?
 1
 ```
 
+* Validating mutiple files with a single flag
+```bash
+kubeconform fixtures/valid.yaml,fixtures/valid_version.yaml
+```
+
 * Passing manifests via Stdin
 ```bash
 cat fixtures/valid.yaml  | ./bin/kubeconform -summary

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,7 +91,14 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 	c.RejectKinds = splitCSV(rejectKindsCSV)
 	c.IgnoreFilenamePatterns = ignoreFilenamePatterns
 	c.SchemaLocations = schemaLocationsParam
-	c.Files = flags.Args()
+	files := flags.Args()
+	for _, file := range files {
+		if strings.Contains(file, ",") {
+			c.Files = append(c.Files, strings.Split(file, ",")...)
+		} else {
+			c.Files = append(c.Files, file)
+		}
+	}
 
 	if c.Help {
 		flags.Usage()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -129,6 +129,18 @@ func TestFromFlags(t *testing.T) {
 				Verbose:              true,
 			},
 		},
+		{
+			[]string{"file1,file2,file3"},
+			Config{
+				Files:             []string{"file1", "file2", "file3"},
+				KubernetesVersion: "master",
+				NumberOfWorkers:   4,
+				OutputFormat:      "text",
+				SchemaLocations:   nil,
+				SkipKinds:         map[string]struct{}{},
+				RejectKinds:       map[string]struct{}{},
+			},
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
This is useful when the target files need to pass as parameters. Such as:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ClusterWorkflowTemplate
metadata:
  name: library-validation
spec:
  templates:
  - name: kubeconform
    inputs:
      parameters:
        - name: target
          default: "."
    container:
      args:
        - "{{inputs.parameters.target}}"
      command:
        - /kubeconform
      image: ghcr.io/yannh/kubeconform:master
```

With this PR, users could pass multiple files like this:

```yaml
        - name: yaml-check
          depends: clone
          templateRef:
            name: library-validation
            template: kubeconform
            clusterScope: true
          arguments:
            parameters:
              - name: target
                value: "config/manager,config/rbac"
```