### PR TITLE
feat: support to set an alternative image owner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       - name: goreleaser
         run: |
           echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-          make release
+          GITHUB_ACTOR=$(echo ${GITHUB_ACTOR} | tr '[:upper:]' '[:lower:]')
+          GIT_OWNER=${GITHUB_ACTOR} make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
       - CGO_ENABLED=0
       - GOFLAGS = -mod=vendor
       - GO111MODULE = on
+      - GIT_OWNER = yannh
     goos:
       - windows
       - linux
@@ -31,18 +32,18 @@ archives:
 
 dockers:
   - image_templates:
-      - 'ghcr.io/yannh/kubeconform:latest'
-      - 'ghcr.io/yannh/kubeconform:{{ .Tag }}'
-      - 'ghcr.io/yannh/kubeconform:{{ .Tag }}-amd64'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64'
     dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/amd64"
     goos: linux
     goarch: amd64
   - image_templates:
-      - 'ghcr.io/yannh/kubeconform:latest-alpine'
-      - 'ghcr.io/yannh/kubeconform:{{ .Tag }}-alpine'
-      - 'ghcr.io/yannh/kubeconform:{{ .Tag }}-amd64-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64-alpine'
     dockerfile: Dockerfile-alpine
     build_flag_templates:
       - "--platform=linux/amd64"

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ goreleaser-build-static:
 	cp dist/kubeconform_linux_amd64_v1/kubeconform bin/
 
 release:
-	docker run -e GITHUB_TOKEN -t -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v1.11.5 release --rm-dist
+	docker run -e GITHUB_TOKEN -e GIT_OWNER -t -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v1.11.5 release --rm-dist
 
 update-deps:
 	go get -u ./...


### PR DESCRIPTION
This is useful when contributors want to test their pull request. And even they could use their pull request before it got merged.