### PR TITLE
support disabling ssl validation in openapi2jsonschema.py

### DIFF
--- a/scripts/Dockerfile.bats
+++ b/scripts/Dockerfile.bats
@@ -1,6 +1,7 @@
 FROM python:3.9.7-alpine3.14
 RUN apk --no-cache add bats
-COPY acceptance.bats openapi2jsonschema.py requirements.txt /code/
+COPY requirements.txt /code/
+RUN pip install -r /code/requirements.txt
 COPY fixtures /code/fixtures
+COPY acceptance.bats openapi2jsonschema.py /code/
 WORKDIR /code
-RUN pip install -r requirements.txt

--- a/scripts/acceptance.bats
+++ b/scripts/acceptance.bats
@@ -5,6 +5,42 @@ setup() {
   rm -f prometheus-monitoring-v1.json
 }
 
+@test "Should generate expected prometheus resource while disable ssl env var is set" {
+  run export DISABLE_SSL_CERT_VALIDATION=true
+  run ./openapi2jsonschema.py fixtures/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+  [ "$status" -eq 0 ]
+  [ "$output" = "JSON schema written to prometheus_v1.json" ]
+  run diff prometheus_v1.json ./fixtures/prometheus_v1-expected.json
+  [ "$status" -eq 0 ]
+}
+
+@test "Should generate expected prometheus resource from an HTTPS resource while disable ssl env var is set" {
+  run export DISABLE_SSL_CERT_VALIDATION=true
+  run ./openapi2jsonschema.py https://raw.githubusercontent.com/yannh/kubeconform/aebc298047c386116eeeda9b1ada83671a58aedd/scripts/fixtures/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+  [ "$status" -eq 0 ]
+  [ "$output" = "JSON schema written to prometheus_v1.json" ]
+  run diff prometheus_v1.json ./fixtures/prometheus_v1-expected.json
+  [ "$status" -eq 0 ]
+}
+
+@test "Should output filename in {kind}-{group}-{version} format while disable ssl env var is set" {
+  run export DISABLE_SSL_CERT_VALIDATION=true
+  FILENAME_FORMAT='{kind}-{group}-{version}' run ./openapi2jsonschema.py fixtures/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+  [ "$status" -eq 0 ]
+  [ "$output" = "JSON schema written to prometheus-monitoring-v1.json" ]
+  run diff prometheus-monitoring-v1.json ./fixtures/prometheus_v1-expected.json
+  [ "$status" -eq 0 ]
+}
+
+@test "Should set 'additionalProperties: false' at the root while disable ssl env var is set" {
+  run export DISABLE_SSL_CERT_VALIDATION=true
+  DENY_ROOT_ADDITIONAL_PROPERTIES='true' run ./openapi2jsonschema.py fixtures/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+  [ "$status" -eq 0 ]
+  [ "$output" = "JSON schema written to prometheus_v1.json" ]
+  run diff prometheus_v1.json ./fixtures/prometheus_v1-denyRootAdditionalProperties.json
+  [ "$status" -eq 0 ]
+}
+
 @test "Should generate expected prometheus resource" {
   run ./openapi2jsonschema.py fixtures/prometheus-operator-0prometheusCustomResourceDefinition.yaml
   [ "$status" -eq 0 ]

--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -6,6 +6,9 @@ import json
 import sys
 import os
 import urllib.request
+if 'DISABLE_SSL_CERT_VALIDATION' in os.environ:
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
 
 def test_additional_properties():
     for test in iter([{


### PR DESCRIPTION
Fixes #157

not the best implementation, but the pr has the minimal changes required in order to run this script on MAC without an issue. If the pr is approved, will edit the README as well