### PR TITLE
Try to expose JSON paths

### DIFF
--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -50,11 +50,15 @@ func (o *jsono) Write(result validator.Result) error {
 		o.nValid++
 	case validator.Invalid:
 		st = "statusInvalid"
-		msg = result.Err.Error()
+		if result.Err != nil {
+			msg = result.Err.Error()
+		}
 		o.nInvalid++
 	case validator.Error:
 		st = "statusError"
-		msg = result.Err.Error()
+		if result.Err != nil {
+			msg = result.Err.Error()
+		}
 		o.nErrors++
 	case validator.Skipped:
 		st = "statusSkipped"

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -9,12 +9,13 @@ import (
 )
 
 type oresult struct {
-	Filename string `json:"filename"`
-	Kind     string `json:"kind"`
-	Name     string `json:"name"`
-	Version  string `json:"version"`
-	Status   string `json:"status"`
-	Msg      string `json:"msg"`
+	Filename         string                      `json:"filename"`
+	Kind             string                      `json:"kind"`
+	Name             string                      `json:"name"`
+	Version          string                      `json:"version"`
+	Status           string                      `json:"status"`
+	Msg              string                      `json:"msg"`
+	ValidationErrors []validator.ValidationError `json:"validationErrors,omitempty"`
 }
 
 type jsono struct {
@@ -63,7 +64,15 @@ func (o *jsono) Write(result validator.Result) error {
 
 	if o.verbose || (result.Status != validator.Valid && result.Status != validator.Skipped && result.Status != validator.Empty) {
 		sig, _ := result.Resource.Signature()
-		o.results = append(o.results, oresult{Filename: result.Resource.Path, Kind: sig.Kind, Name: sig.Name, Version: sig.Version, Status: st, Msg: msg})
+		o.results = append(o.results, oresult{
+			Filename:         result.Resource.Path,
+			Kind:             sig.Kind,
+			Name:             sig.Name,
+			Version:          sig.Version,
+			Status:           st,
+			Msg:              msg,
+			ValidationErrors: result.ValidationErrors,
+		})
 	}
 
 	return nil

--- a/pkg/output/json_test.go
+++ b/pkg/output/json_test.go
@@ -95,6 +95,60 @@ metadata:
 }
 `,
 		},
+		{
+			"a single invalid deployment, verbose, with summary",
+			true,
+			false,
+			true,
+			[]validator.Result{
+				{
+					Resource: resource.Resource{
+						Path: "deployment.yml",
+						Bytes: []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "my-app"
+`),
+					},
+					Status: validator.Invalid,
+					Err: &validator.ValidationError{
+						Path: "foo",
+						Msg:  "bar",
+					},
+					ValidationErrors: []validator.ValidationError{
+						{
+							Path: "foo",
+							Msg:  "bar",
+						},
+					},
+				},
+			},
+			`{
+  "resources": [
+    {
+      "filename": "deployment.yml",
+      "kind": "Deployment",
+      "name": "my-app",
+      "version": "apps/v1",
+      "status": "statusInvalid",
+      "msg": "bar",
+      "validationErrors": [
+        {
+          "path": "foo",
+          "msg": "bar"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "valid": 0,
+    "invalid": 1,
+    "errors": 0,
+    "skipped": 0
+  }
+}
+`,
+		},
 	} {
 		w := new(bytes.Buffer)
 		o := jsonOutput(w, testCase.withSummary, testCase.isStdin, testCase.verbose)

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,12 +28,12 @@ const (
 )
 
 type ValidationError struct {
-	Path    string
-	Message string
+	Path string `json:"path"`
+	Msg  string `json:"msg"`
 }
 
 func (ve *ValidationError) Error() string {
-	return ve.Message
+	return ve.Msg
 }
 
 // Result contains the details of the result of a resource validation
@@ -197,8 +197,8 @@ func (val *v) ValidateResource(res resource.Resource) Result {
 		if errors.As(err, &e) {
 			for _, ve := range e.Causes {
 				validationErrors = append(validationErrors, ValidationError{
-					Path:    ve.KeywordLocation,
-					Message: ve.Message,
+					Path: ve.KeywordLocation,
+					Msg:  ve.Message,
 				})
 			}
 


### PR DESCRIPTION
```
{
  "resources": [
    {
      "filename": "./fixtures/invalid.yaml",
      "kind": "ReplicationController",
      "name": "123",
      "version": "v1",
      "status": "statusInvalid",
      "msg": "problem validating schema. Check JSON formatting: jsonschema: '/metadata/name' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone/replicationcontroller-v1.json#/properties/metadata/properties/name/type: expected string or null, but got number",
      "validationErrors": [
        {
          "Path": "/properties/metadata/properties/name/type",
          "Message": "expected string or null, but got number"
        },
        {
          "Path": "/properties/spec/properties/replicas/type",
          "Message": "expected integer or null, but got string"
        }
      ]
    }
  ],
  "summary": {
    "valid": 0,
    "invalid": 1,
    "errors": 0,
    "skipped": 0
  }
}
```