### PR TITLE
fix: expose error instance path instead of schema path

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -197,7 +197,7 @@ func (val *v) ValidateResource(res resource.Resource) Result {
 		if errors.As(err, &e) {
 			for _, ve := range e.Causes {
 				validationErrors = append(validationErrors, ValidationError{
-					Path: ve.KeywordLocation,
+					Path: ve.InstanceLocation,
 					Msg:  ve.Message,
 				})
 			}


### PR DESCRIPTION
Expose property path in validated document instead of location in schema, so it will be possible to point user to exact location.

xref https://github.com/yannh/kubeconform/issues/156
https://github.com/yannh/kubeconform/pull/173