### PR TITLE
refactor: expose Kubeconform as a module

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yannh/kubeconform/cmd/kubeconform"
+	"github.com/yannh/kubeconform/pkg/config"
+)
+
+var version = "development"
+
+func main() {
+	cfg, out, err := config.FromFlags(os.Args[0], os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed parsing command line: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	if err = kubeconform.Validate(cfg, out); err != nil {
+		fmt.Fprintf(os.Stderr, "failed validating resources: %s - %s\n", err.Error(), out)
+		os.Exit(1)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,8 +4,16 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 )
+
+type Stream struct {
+	Input  io.Reader
+	Output io.Writer
+	Error  io.Writer
+}
 
 type Config struct {
 	Cache                  string
@@ -26,6 +34,7 @@ type Config struct {
 	IgnoreFilenamePatterns []string
 	Help                   bool
 	Version                bool
+	Stream                 *Stream
 }
 
 type arrayParam []string
@@ -62,7 +71,9 @@ func FromFlags(progName string, args []string) (Config, string, error) {
 
 	c := Config{}
 	c.Files = []string{}
+	c.Stream = &Stream{os.Stdin, os.Stdout, os.Stderr}
 
+	flags.SetOutput(c.Stream.Output)
 	flags.StringVar(&c.KubernetesVersion, "kubernetes-version", "master", "version of Kubernetes to validate against, e.g.: 1.18.0")
 	flags.Var(&schemaLocationsParam, "schema-location", "override schemas location search path (can be specified multiple times)")
 	flags.StringVar(&skipKindsCSV, "skip", "", "comma-separated list of kinds or GVKs to ignore")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,25 +16,46 @@ type Stream struct {
 }
 
 type Config struct {
-	Cache                  string
-	Debug                  bool
-	ExitOnError            bool
-	Files                  []string
-	SchemaLocations        []string
-	SkipTLS                bool
-	SkipKinds              map[string]struct{}
+	Cache                  string   `yaml:"cache" json:"cache"`
+	Debug                  bool     `yaml:"debug" json:"debug"`
+	ExitOnError            bool     `yaml:"exitOnError" json:"exitOnError"`
+	Files                  []string `yaml:"files" json:"files"`
+	Help                   bool     `yaml:"help" json:"help"`
+	IgnoreFilenamePatterns []string `yaml:"ignoreFilenamePatterns" json:"ignoreFilenamePatterns"`
+	IgnoreMissingSchemas   bool     `yaml:"ignoreMissingSchemas" json:"ignoreMissingSchemas"`
+	KubernetesVersion      string   `yaml:"kubernetesVersion" json:"kubernetesVersion"`
+	NumberOfWorkers        int      `yaml:"numberOfWorkers" json:"numberOfWorkers"`
+	OutputFormat           string   `yaml:"output" json:"output"`
 	RejectKinds            map[string]struct{}
-	OutputFormat           string
-	KubernetesVersion      string
-	NumberOfWorkers        int
-	Summary                bool
-	Strict                 bool
-	Verbose                bool
-	IgnoreMissingSchemas   bool
-	IgnoreFilenamePatterns []string
-	Help                   bool
-	Version                bool
+	RejectKindsNG          []string `yaml:"reject" json:"reject"`
+	SchemaLocations        []string `yaml:"schemaLocations" json:"schemaLocations"`
+	SkipKinds              map[string]struct{}
+	SkipKindsNG            []string `yaml:"skip" json:"skip"`
+	SkipTLS                bool     `yaml:"insecureSkipTLSVerify" json:"insecureSkipTLSVerify"`
+	Strict                 bool     `yaml:"strict" json:"strict"`
+	Summary                bool     `yaml:"summary" json:"summary"`
+	Verbose                bool     `yaml:"verbose" json:"verbose"`
+	Version                bool     `yaml:"version" json:"version"`
 	Stream                 *Stream
+}
+
+// LoadNGConfig allows to introduce new config format/structure while keeping backward compatibility.
+func (c *Config) LoadNGConfig() error {
+	// SkipKindsNG.
+	loadKinds(c.SkipKinds, c.SkipKindsNG)
+
+	// RejectKindsNG.
+	loadKinds(c.RejectKinds, c.RejectKindsNG)
+
+	return nil
+}
+
+func loadKinds(dest map[string]struct{}, src []string) {
+	for _, kind := range src {
+		if len(kind) > 0 {
+			dest[kind] = struct{}{}
+		}
+	}
 }
 
 type arrayParam []string
@@ -49,15 +70,8 @@ func (ap *arrayParam) Set(value string) error {
 }
 
 func splitCSV(csvStr string) map[string]struct{} {
-	splitValues := strings.Split(csvStr, ",")
 	valuesMap := map[string]struct{}{}
-
-	for _, kind := range splitValues {
-		if len(kind) > 0 {
-			valuesMap[kind] = struct{}{}
-		}
-	}
-
+	loadKinds(valuesMap, strings.Split(csvStr, ","))
 	return valuesMap
 }
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/yannh/kubeconform/pkg/validator"
 )
@@ -12,9 +12,7 @@ type Output interface {
 	Flush() error
 }
 
-func New(outputFormat string, printSummary, isStdin, verbose bool) (Output, error) {
-	w := os.Stdout
-
+func New(w io.Writer, outputFormat string, printSummary, isStdin, verbose bool) (Output, error) {
 	switch {
 	case outputFormat == "json":
 		return jsonOutput(w, printSummary, isStdin, verbose), nil


### PR DESCRIPTION
Hi again :wave:

As mentioned in PR no. #170, instead of dealing with KRM inside Kubeconform, it's better to expose it as a module and use it externally.

In the PR:
- Expose the main logic of Kubeconform to be used as an `app` (not as `lib`) inside other applications (e.g. [KubeconformValidator](https://github.com/aabouzaid/kustomize-kubeconformvalidator) (a [Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) plugin).
- Expose Kubeconform config with proper YAML and JSON tags so it's easy to unmarshal 
- No breaking changes, all original behaviours are kept as it is.

Fixes: #160

Best Regards.