### PR TITLE
Use kubeconform as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: kubeconform
+  name: kubeconform
+  entry: kubeconform
+  language: golang
+  types: [yaml]
+  require_serial: true


### PR DESCRIPTION
I would like to use kubeconform as a pre-commit hook in my projects, so I tried and added a simple pre-commit manifest to the repo. I tested it briefly, and it seem to work fine. 

The only unusual thing I had to do was to set `require_serial: true` in the manifest. That prevents pre-commit from calling kubeconform in parallel. I found it rather confusing, and I guess one should manage concurrency at kubeconform level (using the `-n` flag).