### PR TITLE
Fix for 196: Multi-architecture image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           fetch-depth: 0 # https://github.com/goreleaser/goreleaser-action/issues/56
 
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+ 
       - name: goreleaser
         run: |
           echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,23 +32,63 @@ archives:
 
 dockers:
   - image_templates:
-      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest'
-      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}'
       - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-amd64'
     dockerfile: Dockerfile
+    use: buildx
     build_flag_templates:
+      - "--pull"
       - "--platform=linux/amd64"
     goos: linux
     goarch: amd64
   - image_templates:
-      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-alpine'
-      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-alpine'
-      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64-alpine'
-    dockerfile: Dockerfile-alpine
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-arm64'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-arm64'
+    dockerfile: Dockerfile
+    use: buildx
     build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    goos: linux
+    goarch: arm64
+  - image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-amd64-alpine'
+    dockerfile: Dockerfile-alpine
+    use: buildx
+    build_flag_templates:
+      - "--pull"
       - "--platform=linux/amd64"
     goos: linux
     goarch: amd64
+  - image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-arm64-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-arm64-alpine'
+    dockerfile: Dockerfile-alpine
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    goos: linux
+    goarch: arm64
+
+docker_manifests:
+  - name_template: 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}'
+    image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-arm64'
+  - name_template: 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest'
+    image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-amd64'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-arm64'
+  - name_template: 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-alpine'
+    image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-amd64-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:latest-arm64-alpine'
+  - name_template: 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-alpine'
+    image_templates:
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-amd64-alpine'
+      - 'ghcr.io/{{.Env.GIT_OWNER}}/kubeconform:{{ .Tag }}-arm64-alpine'
 
 checksum:
   name_template: 'CHECKSUMS'


### PR DESCRIPTION
Compare (on a m1 mac mini)

```
> docker run ghcr.io/yannh/kubeconform:v0.6.1 -v            
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
v0.6.1
```
with
```
> docker run ghcr.io/denisa/kubeconform:v0.6.3-dna.7 -v      
v0.6.3-dna.7
```

Note that I followed [GoReleaser build multi arch Docker Images](https://blog.devgenius.io/goreleaser-build-multi-arch-docker-images-8dd9a7903675) for the `latest` tag.