### PR TITLE
fix: add missing output formats in error message

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -25,6 +25,6 @@ func New(w io.Writer, outputFormat string, printSummary, isStdin, verbose bool) 
 	case outputFormat == "text":
 		return textOutput(w, printSummary, isStdin, verbose), nil
 	default:
-		return nil, fmt.Errorf("`outputFormat` must be 'json', 'tap' or 'text'")
+		return nil, fmt.Errorf("'outputFormat' must be 'json', 'junit', 'pretty', 'tap' or 'text'")
 	}
 }


### PR DESCRIPTION
- Add missing 'junit' and 'pretty' output formats.
- Use quotes vs. backticks around command name

Note:
* I can revert the change removing the backticks, or, if you prefer, I could bold it, which might look better?
* I don't know if you want `output` or `-output` vs `outputFormat`? The user typically invokes the format using `-output`, I think.
* Could also make this a data structure and try to DRY it up a little, to make the error self-update?