### PR TITLE
Support providing custom Registries

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -61,6 +61,7 @@ type Opts struct {
 	KubernetesVersion    string              // Kubernetes Version - has to match one in https://github.com/instrumenta/kubernetes-json-schema
 	Strict               bool                // thros an error if resources contain undocumented fields
 	IgnoreMissingSchemas bool                // skip a resource if no schema for that resource can be found
+	Registries           []registry.Registry // Custom Registries to include for accessing schemas.
 }
 
 // New returns a new Validator
@@ -71,7 +72,7 @@ func New(schemaLocations []string, opts Opts) (Validator, error) {
 		schemaLocations = []string{"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json"}
 	}
 
-	registries := []registry.Registry{}
+	registries := opts.Registries
 	for _, schemaLocation := range schemaLocations {
 		reg, err := registry.New(schemaLocation, opts.Cache, opts.Strict, opts.SkipTLS, opts.Debug)
 		if err != nil {


### PR DESCRIPTION
closes: https://github.com/yannh/kubeconform/issues/215

Inserts custom Registries at the beginning of the list of all registries. Supports the use case(s) outlined in the above issue. Tried using this change in our project and it worked really well for us.


Let me know what you think about this approach. Open to other suggestions. 