### PR TITLE
Fix #130 in a backward-compatible way

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
                           filename = filename_format.format(
                               kind=y["spec"]["names"]["kind"],
                               group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
                               version=version["name"],
                           ).lower() + ".json"
 
@@ -164,6 +165,7 @@ if __name__ == "__main__":
                           filename = filename_format.format(
                               kind=y["spec"]["names"]["kind"],
                               group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
                               version=version["name"],
                           ).lower() + ".json"
 
@@ -173,6 +175,7 @@ if __name__ == "__main__":
                   filename = filename_format.format(
                       kind=y["spec"]["names"]["kind"],
                       group=y["spec"]["group"].split(".")[0],
+                      fullgroup=y["spec"]["group"],
                       version=y["spec"]["version"],
                   ).lower() + ".json"
 


### PR DESCRIPTION
This is an alternative way to fix #130.
Instead of changing the `group` variable content, this commit adds
a new variable `fullgroup` that does not split the group components.

With this, users can specify the filename format like:

    FILENAME_FORMAT='{fullgroup}-{version}-{kind}'