### PR TITLE
Sanitize csv strings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,11 +59,11 @@ func (kv *k8sVersionValue) UnmarshalText(v []byte) error {
 }
 
 func splitCSV(csvStr string) map[string]struct{} {
-	sanitizedValues := strings.ReplaceAll(csvStr, " ", "")
-	splitValues := strings.Split(sanitizedValues, ",")
+	splitValues := strings.Split(csvStr, ",")
 	valuesMap := map[string]struct{}{}
 
 	for _, kind := range splitValues {
+		kind = strings.TrimSpace(kind)
 		if len(kind) > 0 {
 			valuesMap[kind] = struct{}{}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,8 @@ func (kv *k8sVersionValue) UnmarshalText(v []byte) error {
 }
 
 func splitCSV(csvStr string) map[string]struct{} {
-	splitValues := strings.Split(csvStr, ",")
+	sanitizedValues := strings.ReplaceAll(csvStr, " ", "")
+	splitValues := strings.Split(sanitizedValues, ",")
 	valuesMap := map[string]struct{}{}
 
 	for _, kind := range splitValues {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -96,6 +96,30 @@ func TestFromFlags(t *testing.T) {
 			},
 		},
 		{
+			[]string{"-skip", "a, b, c"},
+			Config{
+				Files:             []string{},
+				KubernetesVersion: "master",
+				NumberOfWorkers:   4,
+				OutputFormat:      "text",
+				SchemaLocations:   nil,
+				SkipKinds:         map[string]struct{}{"a": {}, "b": {}, "c": {}},
+				RejectKinds:       map[string]struct{}{},
+			},
+		},
+		{
+			[]string{"-skip", "a,b, c"},
+			Config{
+				Files:             []string{},
+				KubernetesVersion: "master",
+				NumberOfWorkers:   4,
+				OutputFormat:      "text",
+				SchemaLocations:   nil,
+				SkipKinds:         map[string]struct{}{"a": {}, "b": {}, "c": {}},
+				RejectKinds:       map[string]struct{}{},
+			},
+		},
+		{
 			[]string{"-summary", "-verbose", "file1", "file2"},
 			Config{
 				Files:             []string{"file1", "file2"},


### PR DESCRIPTION
This should be a simple fix to #256 

Two additional test cases were implemented to check some cases of possible input value patterns.
The fix itself is realized within the splitCSV function, which now by default replaces all " " by "".

I'm aware, that this might not be the most suitable place for this fix. 
I thought of implementing it in one of the higher level function but was not sure about implications.

Feel free to comment of course :)