### PR TITLE
openapi2jsonschema: Allow writting to subdirectories

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -102,7 +102,16 @@ def write_schema_file(schema, filename):
     schemaJSON = json.dumps(schema, indent=2)
 
     # Dealing with user input here..
-    filename = os.path.basename(filename)
+    cwd = Path.cwd()
+    abspath = Path(filename).resolve()
+    if cwd in abspath.parents:
+        filename = abspath.relative_to(cwd)
+        if not filename.parent.exists():
+            filename.parent.mkdir(parents=True)
+    else:
+        print("Trying to write to a file outside of the current directory, aborting.")
+        exit(1)
+        
     f = open(filename, "w")
     print(schemaJSON, file=f)
     f.close()


### PR DESCRIPTION
This pull requests extends the `openapi2jsonschema.py` allowing to write to a subdirectory of the current working directory.

The filename templated from `FILENAME_FORMAT` is verified to be a child of the working directory, and if the subdirectory doesn't exist yet, it's created.

