### PR TITLE
chore: disable http logger

### DIFF
--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -54,6 +54,9 @@ func newHTTPRegistry(schemaPathTemplate string, cacheFolder string, strict bool,
 
 	// retriable http client
 	retryClient := retryablehttp.NewClient()
+	if !debug {
+		retryClient.Logger = nil
+	}
 	retryClient.RetryMax = 2
 	retryClient.HTTPClient = &http.Client{Transport: reghttp}
 


### PR DESCRIPTION
when not using debug