### PR TITLE
Improve condition for checking if CRD file is a URL

### DIFF
--- a/scripts/openapi2jsonschema.py
+++ b/scripts/openapi2jsonschema.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
       exit(1)
 
   for crdFile in sys.argv[1:]:
-      if crdFile.startswith("http"):
+      if crdFile.startswith("http:") or crdFile.startsWith("https:"):
         f = urllib.request.urlopen(crdFile)
       else:
         f = open(crdFile)


### PR DESCRIPTION
Was stumped by this when attempting to include a local CRD file named `httproutes.gateway.networking.k8s.io.json` - which resulted in the following error:

```
ValueError: unknown url type: 'httproutes.gateway.networking.k8s.io.json'
```

Assuming that all `startsWith("http")` was intended to do is discerning local from remote resource references.