### PR TITLE
Allow duration format used in Kubernetes API machinery

### DIFF
--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -377,6 +377,87 @@ lastName: bar
 			Error,
 			[]ValidationError{},
 		},
+		{
+			"valid resource duration - go format",
+			[]byte(`
+kind: name
+apiVersion: v1
+interval: 5s
+`),
+			[]byte(`{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string"
+    },
+	"interval": {
+      "type": "string",
+	  "format": "duration"
+    }
+  },
+  "required": ["interval"]
+}`),
+			nil,
+			false,
+			false,
+			Valid,
+			[]ValidationError{},
+		},
+		{
+			"valid resource duration - iso8601 format",
+			[]byte(`
+kind: name
+apiVersion: v1
+interval: PT1H
+`),
+			[]byte(`{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string"
+    },
+	"interval": {
+      "type": "string",
+	  "format": "duration"
+    }
+  },
+  "required": ["interval"]
+}`),
+			nil,
+			false,
+			false,
+			Valid,
+			[]ValidationError{},
+		},
+		{
+			"invalid resource duration",
+			[]byte(`
+kind: name
+apiVersion: v1
+interval: test
+`),
+			[]byte(`{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string"
+    },
+	"interval": {
+      "type": "string",
+	  "format": "duration"
+    }
+  },
+  "required": ["interval"]
+}`),
+			nil,
+			false,
+			false,
+			Invalid,
+			[]ValidationError{{Path: "/interval", Msg: "'test' is not valid 'duration'"}},
+		},
 	} {
 		val := v{
 			opts: Opts{


### PR DESCRIPTION
Fixes #300 to allow duration format commonly used across Kubernetes operators.

While this could potentially be fixed in upstream github.com/santhosh-tekuri/jsonschema I think this validation is very much up to the interpretation of the RFC and it would probably require an upgrade to `v6` which has changed APIs in the package and would require a lot of refactoring.