### PR TITLE
Invalid JSON should not be considered an error - see https://github.c…

### DIFF
--- a/pkg/loader/http.go
+++ b/pkg/loader/http.go
@@ -56,7 +56,7 @@ func (l *HTTPURLLoader) Load(url string) (any, error) {
 
 	s, err := jsonschema.UnmarshalJSON(bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, NewNonJSONResponseError(err)
 	}
 
 	return s, nil

--- a/pkg/loader/loaders.go
+++ b/pkg/loader/loaders.go
@@ -10,3 +10,13 @@ func NewNotFoundError(err error) *NotFoundError {
 }
 func (e *NotFoundError) Error() string   { return e.err.Error() }
 func (e *NotFoundError) Retryable() bool { return false }
+
+type NonJSONResponseError struct {
+	err error
+}
+
+func NewNonJSONResponseError(err error) *NotFoundError {
+	return &NotFoundError{err}
+}
+func (e *NonJSONResponseError) Error() string   { return e.err.Error() }
+func (e *NonJSONResponseError) Retryable() bool { return false }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -309,6 +309,10 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 		if _, notfound := err.(*loader.NotFoundError); notfound {
 			continue
 		}
+		if _, nonJSONError := err.(*loader.NonJSONResponseError); nonJSONError {
+			continue
+		}
+
 		return nil, err
 	}
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -316,7 +316,7 @@ lastName: bar
 }`),
 			false,
 			false,
-			Error,
+			Valid,
 			[]ValidationError{},
 		},
 		{
@@ -361,7 +361,7 @@ lastName: bar
 			[]byte(`<html>error page</html>`),
 			true,
 			false,
-			Error,
+			Skipped,
 			[]ValidationError{},
 		},
 		{
@@ -394,6 +394,9 @@ lastName: bar
 						return "", nil, loader.NewNotFoundError(nil)
 					}
 					s, err := jsonschema.UnmarshalJSON(bytes.NewReader(testCase.schemaRegistry1))
+					if err != nil {
+						return "", s, loader.NewNonJSONResponseError(err)
+					}
 					return "", s, err
 				}),
 				newMockRegistry(func() (string, any, error) {
@@ -401,6 +404,9 @@ lastName: bar
 						return "", nil, loader.NewNotFoundError(nil)
 					}
 					s, err := jsonschema.UnmarshalJSON(bytes.NewReader(testCase.schemaRegistry2))
+					if err != nil {
+						return "", s, loader.NewNonJSONResponseError(err)
+					}
 					return "", s, err
 				}),
 			},
@@ -469,6 +475,9 @@ age: not a number
 		regs: []registry.Registry{
 			newMockRegistry(func() (string, any, error) {
 				s, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+				if err != nil {
+					return "", s, loader.NewNonJSONResponseError(err)
+				}
 				return "", s, err
 			}),
 		},


### PR DESCRIPTION
…om/yannh/kubeconform/issues/67

Re-instates the previous behaviour for handling schema parsing errors, for backward compatibility for the linked issue