### PR TITLE
feat(validator): use jsonschema Draft2020

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -5,6 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/yannh/kubeconform/pkg/cache"
 	"github.com/yannh/kubeconform/pkg/loader"
@@ -12,11 +17,7 @@ import (
 	"github.com/yannh/kubeconform/pkg/resource"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"io"
-	"os"
 	"sigs.k8s.io/yaml"
-	"strings"
-	"time"
 )
 
 // Different types of validation results
@@ -375,7 +376,7 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 			c := jsonschema.NewCompiler()
 			c.RegisterFormat(&jsonschema.Format{"duration", validateDuration})
 			c.UseLoader(l)
-			c.DefaultDraft(jsonschema.Draft4)
+			c.DefaultDraft(jsonschema.Draft2020)
 			if err := c.AddResource(path, s); err != nil {
 				continue
 			}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -377,6 +377,7 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 			c.RegisterFormat(&jsonschema.Format{"duration", validateDuration})
 			c.UseLoader(l)
 			c.DefaultDraft(jsonschema.Draft2020)
+			c.AssertFormat()
 			if err := c.AddResource(path, s); err != nil {
 				continue
 			}


### PR DESCRIPTION
Uses current jsonschema as draft: https://json-schema.org/draft/2020-12 

I also hat to add `c.AssertFormat()` to fix the tests

This fixes my issue #345


tested with: 

```
$ make 
$ go build -o bin/kubeconform cmd/kubeconform/main.go
$ go test -v ./...
?       github.com/yannh/kubeconform/cmd/kubeconform    [no test files]
?       github.com/yannh/kubeconform/examples   [no test files]
?       github.com/yannh/kubeconform/pkg/cache  [no test files]
=== RUN   TestSkipKindMaps
--- PASS: TestSkipKindMaps (0.00s)
=== RUN   TestFromFlags
--- PASS: TestFromFlags (0.00s)
PASS
ok      github.com/yannh/kubeconform/pkg/config 0.002s
=== RUN   TestHTTPURLLoader_Load
=== RUN   TestHTTPURLLoader_Load/successful_load
=== RUN   TestHTTPURLLoader_Load/not_found_error
=== RUN   TestHTTPURLLoader_Load/server_error
=== RUN   TestHTTPURLLoader_Load/cache_hit
=== RUN   TestHTTPURLLoader_Load/Partial_response_from_server
--- PASS: TestHTTPURLLoader_Load (0.01s)
    --- PASS: TestHTTPURLLoader_Load/successful_load (0.00s)
    --- PASS: TestHTTPURLLoader_Load/not_found_error (0.00s)
    --- PASS: TestHTTPURLLoader_Load/server_error (0.00s)
    --- PASS: TestHTTPURLLoader_Load/cache_hit (0.00s)
    --- PASS: TestHTTPURLLoader_Load/Partial_response_from_server (0.00s)
=== RUN   TestHTTPURLLoader_Load_Retries
=== RUN   TestHTTPURLLoader_Load_Retries/retries_on_503
=== RUN   TestHTTPURLLoader_Load_Retries/fails_when_hitting_max_retries
=== RUN   TestHTTPURLLoader_Load_Retries/retry_on_connection_reset
=== RUN   TestHTTPURLLoader_Load_Retries/retry_on_connection_reset#01
--- PASS: TestHTTPURLLoader_Load_Retries (8.01s)
    --- PASS: TestHTTPURLLoader_Load_Retries/retries_on_503 (1.00s)
    --- PASS: TestHTTPURLLoader_Load_Retries/fails_when_hitting_max_retries (3.00s)
    --- PASS: TestHTTPURLLoader_Load_Retries/retry_on_connection_reset (1.00s)
    --- PASS: TestHTTPURLLoader_Load_Retries/retry_on_connection_reset#01 (3.00s)
PASS
ok      github.com/yannh/kubeconform/pkg/loader 8.027s
=== RUN   TestJSONWrite
--- PASS: TestJSONWrite (0.00s)
=== RUN   TestJunitWrite
--- PASS: TestJunitWrite (0.00s)
=== RUN   TestPrettyTextWrite
--- PASS: TestPrettyTextWrite (0.00s)
=== RUN   TestTapWrite
--- PASS: TestTapWrite (0.00s)
=== RUN   TestTextWrite
--- PASS: TestTextWrite (0.00s)
PASS
ok      github.com/yannh/kubeconform/pkg/output 0.012s
=== RUN   TestSchemaPath
--- PASS: TestSchemaPath (0.00s)
PASS
ok      github.com/yannh/kubeconform/pkg/registry       0.010s
=== RUN   TestIsYamlFile
--- PASS: TestIsYamlFile (0.00s)
=== RUN   TestIsJSONFile
--- PASS: TestIsJSONFile (0.00s)
=== RUN   TestFindResourcesInReader
--- PASS: TestFindResourcesInReader (0.00s)
=== RUN   TestSignatureFromBytes
--- PASS: TestSignatureFromBytes (0.00s)
=== RUN   TestSignatureFromMap
--- PASS: TestSignatureFromMap (0.00s)
=== RUN   TestResources
--- PASS: TestResources (0.00s)
=== RUN   TestFromStream
--- PASS: TestFromStream (0.01s)
PASS
ok      github.com/yannh/kubeconform/pkg/resource       0.010s
=== RUN   TestValidate
--- PASS: TestValidate (0.00s)
=== RUN   TestValidationErrors
--- PASS: TestValidationErrors (0.00s)
=== RUN   TestValidateFile
--- PASS: TestValidateFile (0.00s)
PASS
ok      github.com/yannh/kubeconform/pkg/validator      0.010s
```
```
$ ./bin/kubeconform -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' test.yaml 
```
```
$ git clone https://github.com/gravitee-io/gravitee-kubernetes-operator /tmp/gravitee-kubernetes-operator
```

script:

```
set -euo pipefail

# Configuration
KUBECONFORM_BIN="$(dirname "$0")/bin/kubeconform"
EXAMPLES_DIR="${EXAMPLES_DIR:-/tmp/gravitee-kubernetes-operator}"
SCHEMA_LOCATIONS=(
    "default"
    "https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
)

# Check if kubeconform binary exists
if [ ! -f "$KUBECONFORM_BIN" ]; then
    echo "Error: kubeconform binary not found at $KUBECONFORM_BIN"
    echo "Please run: go build -o bin/kubeconform cmd/kubeconform/main.go"
    exit 1
fi

# Check if examples directory exists
if [ ! -d "$EXAMPLES_DIR" ]; then
    echo "Error: Examples directory not found at $EXAMPLES_DIR"
    exit 1
fi

# Build schema location arguments
SCHEMA_ARGS=()
for loc in "${SCHEMA_LOCATIONS[@]}"; do
    SCHEMA_ARGS+=("-schema-location" "$loc")
done

# Find all YAML files
find "$EXAMPLES_DIR" -type f \( -name "*.yaml" -o -name "*.yml" \) | while read -r file; do
    echo "Validating: $file"
    "$KUBECONFORM_BIN" "${SCHEMA_ARGS[@]}" "$file"
done
```




