### PR TITLE
Add pre-commit configuration to run kubeconform

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+- id: kubeconform
+  name: kubeconform
+  description: Kubernetes manifest validation
+  entry: kubeconform
+  language: golang
+  pass_filenames: true
+  require_serial: true
+  minimum_pre_commit_version: "2.9.0"
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  exclude: ^\.  # paths starting with .
+  types: ["yaml"]


### PR DESCRIPTION
Contribute a pre-commit hook specification, so https://pre-commit.com/ can discover how to run kubeconform.

Usage, in a project's `.pre-commit-config.yaml`

```yaml
 - repo: https://github.com/yannh/kubeconform
   rev: v0.7.1  # pinned (future) version of kubeconform

   hooks:
   - id: kubeconform
     name: kubeconform run with defaults

   - id: kubeconform
     name: kubeconfirm run with 8 goroutines and extra schemas from crd catalog
     args:
     - -strict # disallow additional properties not in schema or duplicated keys

     # Look in both the default & contributed CRDs-catalog for schemas
     - -schema-location
     - default
     - -schema-location
     - 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

     # skip CRDs and Kustomization resources
     - -skip
     - CustomResourceDefinition,Kustomization

     # parallel
     - -n
     - "8"
```

`$ pre-commit run --files default/whoami.yaml --verbose kubeconform`

```
kubeconform run with defaults..............................................................Failed
- hook id: kubeconform
- duration: 0.36s
- exit code: 1

default/whoami.yaml - IngressRoute whoami failed validation: could not find schema for IngressRoute

kubeconfirm run with 8 goroutines and extra schemas from crd catalog.......................Failed
- hook id: kubeconform
- duration: 0.24s
- exit code: 1

default/whoami.yaml - IngressRoute whoami is invalid: problem validating schema. Check JSON formatting: jsonschema validation failed with 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/traefik.io/ingressroute_v1alpha1.json#' - at '/spec': additional properties 'middlewares-spelling-mistake' not allowed
```