### PR TITLE
fix trivvy vulnerability CVE-2025-68121

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ local-build-static:
 
 # These only used for development. Release artifacts and docker images are produced by goreleaser.
 docker-test:
-	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.3 make local-test
+	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.13 make local-test
 
 docker-build:
-	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.3 make local-build
+	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.13 make local-build
 
 docker-build-static:
-	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.3 make local-build-static
+	docker run -t -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform golang:1.24.13 make local-build-static
 
 build-bats:
 	docker build -t bats -f Dockerfile.bats .
@@ -32,11 +32,11 @@ docker-acceptance: build-bats
 	docker run --network none -t bats -p acceptance-nonetwork.bats
 
 goreleaser-build-static:
-	docker run -t -e GOOS=linux -e GOARCH=amd64 -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v2.9.0 build --clean --single-target --snapshot
+	docker run -t -e GOOS=linux -e GOARCH=amd64 -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v2.15.4 build --clean --single-target --snapshot
 	cp dist/kubeconform_linux_amd64_v1/kubeconform bin/
 
 release:
-	docker run -e GITHUB_TOKEN -e GIT_OWNER -t -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v2.9.0 release --clean
+	docker run -e GITHUB_TOKEN -e GIT_OWNER -t -v /var/run/docker.sock:/var/run/docker.sock -v $$PWD:/go/src/github.com/yannh/kubeconform -w /go/src/github.com/yannh/kubeconform goreleaser/goreleaser:v2.15.4 release --clean
 
 update-deps:
 	go get -u ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yannh/kubeconform
 
-go 1.24
+go 1.24.13
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.7


### PR DESCRIPTION
Our CI/CD pipeline uses kubeconform and complains about [Trivvy CVE-2025-68121](https://nvd.nist.gov/vuln/detail/cve-2025-68121). I want to fix that by upgrading to go version 1.24.13