### PR TITLE
fix: avoid panic when a schema document decodes to null

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -372,6 +372,13 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 	for _, reg := range registries {
 		path, s, err = reg.DownloadSchema(kind, version, k8sVersion)
 		if err == nil {
+			// A schema document that decodes to nil (for example a file whose
+			// entire content is the literal "null") is accepted by AddResource
+			// but makes Compile dereference a nil root and panic. Treat it as a
+			// non-parseable response and try the next registry instead.
+			if s == nil {
+				continue
+			}
 			c := jsonschema.NewCompiler()
 			c.RegisterFormat(&jsonschema.Format{"duration", validateDuration})
 			c.UseLoader(l)

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -460,6 +460,40 @@ interval: test
 			Invalid,
 			[]ValidationError{{Path: "/interval", Msg: "'test' is not valid duration: must start with P"}},
 		},
+		{
+			// A schema file whose entire content is the literal "null" decodes to
+			// a nil document. It used to reach jsonschema's Compile and panic with
+			// a nil pointer dereference (issue #337); it must now be treated as a
+			// missing schema instead.
+			"schema document is null",
+			[]byte(`
+kind: name
+apiVersion: v1
+firstName: foo
+`),
+			[]byte(`null`),
+			nil,
+			true,
+			false,
+			Skipped,
+			[]ValidationError{},
+		},
+		{
+			// Same as above but with IgnoreMissingSchemas disabled: a null schema
+			// document must surface as a graceful Error, not a panic (issue #337).
+			"schema document is null, do not ignore missing",
+			[]byte(`
+kind: name
+apiVersion: v1
+firstName: foo
+`),
+			[]byte(`null`),
+			nil,
+			false,
+			false,
+			Error,
+			[]ValidationError{},
+		},
 	} {
 		val := v{
 			opts: Opts{


### PR DESCRIPTION
A schema file whose entire content is the literal `null` decodes to a nil document. `downloadSchema` passed that nil into the jsonschema compiler, which accepted it via `AddResource` and then dereferenced a nil root inside `Compile`, crashing kubeconform with a SIGSEGV (#337).

This treats a nil-decoding schema as a non-parseable response and tries the next registry, so it ultimately falls through to the existing "schema not found" handling — Skipped with `-ignore-missing-schemas`, otherwise a graceful error.

### Validation
- `go test -race ./... -count=1` — all green, including two new `TestValidate` cases (null schema → Skipped with ignore-missing, → Error without)
- The repro from the issue now exits gracefully (`could not find schema for HTTPRoute`) instead of panicking; with `-ignore-missing-schemas` it reports `Skipped: 1`

closes #337
