### PR TITLE
fix: report scanner errors when reading resources from stdin

### DIFF
--- a/pkg/resource/stream.go
+++ b/pkg/resource/stream.go
@@ -68,6 +68,10 @@ func FromStream(ctx context.Context, path string, r io.Reader) (<-chan Resource,
 			}
 		}
 
+		if err := scanner.Err(); err != nil {
+			errors <- DiscoveryError{path, err}
+		}
+
 		close(resources)
 		close(errors)
 	}()

--- a/pkg/resource/stream_test.go
+++ b/pkg/resource/stream_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"reflect"
 	"strings"
@@ -171,5 +172,49 @@ kind: Deployment
 		}()
 
 		wg.Wait()
+	}
+}
+
+// failingReader serves a first chunk and then fails, the way a broken pipe on
+// stdin does.
+type failingReader struct {
+	head string
+	sent bool
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.sent {
+		return 0, errors.New("read failed")
+	}
+	r.sent = true
+	return copy(p, r.head), nil
+}
+
+func TestFromStreamReadError(t *testing.T) {
+	r := &failingReader{head: "apiVersion: v1\nkind: ReplicationController\n"}
+	resChan, errChan := resource.FromStream(context.Background(), "stdin", r)
+
+	var wg sync.WaitGroup
+	var errs []error
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range resChan {
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for e := range errChan {
+			errs = append(errs, e)
+		}
+	}()
+	wg.Wait()
+
+	if len(errs) != 1 {
+		t.Fatalf("expected the read failure to be reported, got %d errors", len(errs))
+	}
+	if _, ok := errs[0].(resource.DiscoveryError); !ok {
+		t.Errorf("expected a DiscoveryError, got %T", errs[0])
 	}
 }


### PR DESCRIPTION
`FromStream` scans stdin and then closes both channels:

```go
for scanner.Scan() {
    ...
}

close(resources)
close(errors)
```

`scanner.Err()` is never consulted. `Scan` returns false for end of input and for failure alike, so a read error, or a document larger than the 256MB buffer (`bufio.ErrTooLong`), simply ends the loop. Nothing goes onto the error channel, `main` sees no error result, and kubeconform exits 0 having validated only the part of the stream it managed to read. For a validation tool that is the bad direction to fail in: the manifests that never got read are the ones you would want flagged.

`findResourcesInReader` in the same package already handles this:

```go
if err := scanner.Err(); err != nil {
    errors <- DiscoveryError{p, err}
}
```

so files get the check and stdin does not. This adds the same three lines to `FromStream`. `main` already drains the error channel and turns each entry into an `Error` result, so the exit code follows without any other change.

`TestFromStreamReadError` feeds a reader that serves one document and then fails. On the unmodified tree it reports 0 errors; with the change it gets the `DiscoveryError`. `go test ./...` passes.

One note: #363 also touches this function (the `scanner.Bytes()` aliasing race). Different lines, but if you would rather land that first I am happy to rebase on top of it.
