### PR TITLE
Report a schema that was served but could not be used

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -369,6 +369,9 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 	var err error
 	var path string
 	var s any
+	// Why a schema we did receive could not be used. Kept separate from err,
+	// which tracks registry lookup failures.
+	var unusableErr error
 
 	for _, reg := range registries {
 		path, s, err = reg.DownloadSchema(kind, version, k8sVersion)
@@ -385,11 +388,17 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 			c.UseLoader(l)
 			c.DefaultDraft(jsonschema.Draft4)
 			if err := c.AddResource(path, s); err != nil {
+				if unusableErr == nil {
+					unusableErr = fmt.Errorf("schema %s could not be loaded: %w", path, err)
+				}
 				continue
 			}
 			schema, err := c.Compile(path)
 			// If we got a non-parseable response, we try the next registry
 			if err != nil {
+				if unusableErr == nil {
+					unusableErr = fmt.Errorf("schema %s could not be compiled: %w", path, err)
+				}
 				continue
 			}
 			return schema, nil
@@ -403,6 +412,13 @@ func downloadSchema(registries []registry.Registry, l jsonschema.SchemeURLLoader
 		}
 
 		return nil, err
+	}
+
+	// A schema that was served but could not be used is not a missing schema:
+	// reporting it as missing hides the real cause and, with
+	// -ignore-missing-schemas, silently skips the resource.
+	if unusableErr != nil {
+		return nil, unusableErr
 	}
 
 	return nil, nil // No schema found - we don't consider it an error, resource will be skipped

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -691,5 +692,109 @@ firstName: foo
 	}
 	if !reflect.DeepEqual(expectedValidationErrors, gotValidationErrors) {
 		t.Errorf("Expected %+v, got %+v", expectedValidationErrors, gotValidationErrors)
+	}
+}
+
+// --- issue #296 / #305: a schema that is served but cannot be compiled ---
+// Refs https://github.com/yannh/kubeconform/issues/296
+// Refs https://github.com/yannh/kubeconform/issues/305
+
+// unusableSchemaRegistry serves a document that parses as JSON but is not a
+// valid JSON schema: draft-04 requires "type" to be a string or an array.
+func unusableSchemaRegistry() registry.Registry {
+	return newMockRegistry(func() (string, any, error) {
+		s, err := jsonschema.UnmarshalJSON(bytes.NewReader([]byte(`{"type": 123}`)))
+		return "unusable.json", s, err
+	})
+}
+
+func notFoundRegistry() registry.Registry {
+	return newMockRegistry(func() (string, any, error) {
+		return "", nil, loader.NewNotFoundError(nil)
+	})
+}
+
+// RED: downloadSchema must not report "no schema anywhere" when a registry did
+// serve a schema and compiling it failed.
+func TestDownloadSchemaReportsUnusableSchema(t *testing.T) {
+	schema, err := downloadSchema(
+		[]registry.Registry{unusableSchemaRegistry()},
+		jsonschema.SchemeURLLoader{}, "name", "v1", "1.30.0")
+
+	if schema != nil {
+		t.Fatalf("expected no schema, got %v", schema)
+	}
+	if err == nil {
+		t.Fatalf("expected the compile error to be returned, got nil - the reason the schema could not be used is lost")
+	}
+	if !strings.Contains(err.Error(), "metaschema") {
+		t.Errorf("expected the underlying compile error, got %q", err.Error())
+	}
+}
+
+// RED: the user-facing message must name the real cause, not "could not find schema".
+func TestValidateReportsUnusableSchemaCause(t *testing.T) {
+	val := v{
+		opts:           Opts{SkipKinds: map[string]struct{}{}, RejectKinds: map[string]struct{}{}},
+		schemaDownload: downloadSchema,
+		regs:           []registry.Registry{unusableSchemaRegistry()},
+	}
+
+	got := val.ValidateResource(resource.Resource{Bytes: []byte("kind: name\napiVersion: v1\n")})
+
+	if got.Status != Error {
+		t.Fatalf("expected Error, got %d", got.Status)
+	}
+	if got.Err == nil {
+		t.Fatalf("expected an error")
+	}
+	if strings.Contains(got.Err.Error(), "could not find schema") {
+		t.Errorf("schema was found but could not be compiled; message misreports it as missing: %q", got.Err.Error())
+	}
+}
+
+// GUARD (green on base too): a genuinely missing schema must stay a missing
+// schema - (nil, nil) - so that -ignore-missing-schemas keeps working.
+func TestDownloadSchemaMissingSchemaStaysNil(t *testing.T) {
+	schema, err := downloadSchema(
+		[]registry.Registry{notFoundRegistry(), notFoundRegistry()},
+		jsonschema.SchemeURLLoader{}, "name", "v1", "1.30.0")
+
+	if schema != nil || err != nil {
+		t.Fatalf("expected (nil, nil) for a missing schema, got (%v, %v)", schema, err)
+	}
+}
+
+// GUARD (green on base too): -ignore-missing-schemas still skips.
+func TestValidateIgnoreMissingSchemasStillSkips(t *testing.T) {
+	val := v{
+		opts:           Opts{SkipKinds: map[string]struct{}{}, RejectKinds: map[string]struct{}{}, IgnoreMissingSchemas: true},
+		schemaDownload: downloadSchema,
+		regs:           []registry.Registry{notFoundRegistry()},
+	}
+
+	got := val.ValidateResource(resource.Resource{Bytes: []byte("kind: name\napiVersion: v1\n")})
+	if got.Status != Skipped {
+		t.Fatalf("expected Skipped, got %d (err=%v)", got.Status, got.Err)
+	}
+}
+
+// GUARD (green on base too): the first usable schema still wins when an earlier
+// registry served an unusable one.
+func TestDownloadSchemaFallsBackToNextRegistry(t *testing.T) {
+	good := newMockRegistry(func() (string, any, error) {
+		s, err := jsonschema.UnmarshalJSON(bytes.NewReader([]byte(`{"type": "object"}`)))
+		return "good.json", s, err
+	})
+
+	schema, err := downloadSchema(
+		[]registry.Registry{unusableSchemaRegistry(), good},
+		jsonschema.SchemeURLLoader{}, "name", "v1", "1.30.0")
+
+	if err != nil {
+		t.Fatalf("expected the good schema to win, got error %v", err)
+	}
+	if schema == nil {
+		t.Fatalf("expected a schema from the second registry")
 	}
 }


### PR DESCRIPTION
Refs #296. Refs #305.

`downloadSchema` throws away the error from `AddResource` and `Compile` and moves on to the next registry:

    if err := c.AddResource(path, s); err != nil {
        continue
    }
    schema, err := c.Compile(path)
    // If we got a non-parseable response, we try the next registry
    if err != nil {
        continue
    }

When no registry yields a usable schema the function ends at `return nil, nil`, which the caller reads as *no schema exists anywhere*. So a schema that was found and merely failed to compile is reported as

    could not find schema for name

and with `-ignore-missing-schemas` the resource is skipped without a word — the case #305 describes. The reason the schema could not be used never reaches the user, which is what #296 asks for.

This remembers the first such failure and returns it when no registry produced a schema.

### What deliberately did not change

- A genuinely missing schema still returns `(nil, nil)`, so `-ignore-missing-schemas` keeps skipping.
- A later registry can still supply a usable schema after an earlier one served a broken file.
- The `s == nil` branch (issue #337) is untouched.

Each of those three has a test that is green on `master` as well, so they are guards rather than new expectations.

### Measured

On `0563200`, `go test ./pkg/validator/...`:

| | PASS | FAIL |
| --- | --- | --- |
| master | 3 | 0 |
| master + the new tests, without the fix | 6 | **2** |
| with the fix | **8** | 0 |

The two failures on the middle row are the point:

    --- FAIL: TestDownloadSchemaReportsUnusableSchema
        expected the compile error to be returned, got nil - the reason the schema
        could not be used is lost
    --- FAIL: TestValidateReportsUnusableSchemaCause
        schema was found but could not be compiled; message misreports it as
        missing: "could not find schema for name"

`go test ./...` across the repository: 6 packages ok, 0 failed — the same on an untouched checkout. `gofmt -l` is clean. `go vet` reports one unkeyed-field warning on `jsonschema.Format{"duration", validateDuration}`, and reports it identically on `master`; that line is not part of this change.

### One behaviour change worth calling out

With `-ignore-missing-schemas`, a schema that is served but broken now produces an error instead of a silent skip. That is the intent of #305, but it does mean a run that used to pass on a corrupt local schema will now fail. Say the word if you would rather have it stay a skip and only surface under `-verbose`.

AI-assisted (LLM used for drafting); the measurements above are mine.
